### PR TITLE
Fixed a bug in JSONPlainWriter destruction

### DIFF
--- a/include/cereal/archives/json.hpp
+++ b/include/cereal/archives/json.hpp
@@ -192,7 +192,7 @@ namespace cereal
         if (itsNodeStack.top() == NodeType::InObject)
           itsPrettyPrint ? itsPrettyWriter.EndObject() : itsPlainWriter.EndObject();
         else if (itsNodeStack.top() == NodeType::InArray)
-          itsPrettyPrint ? itsPrettyWriter.EndArray() : itsPrettyWriter.EndObject();
+          itsPrettyPrint ? itsPrettyWriter.EndArray() : itsPlainWriter.EndArray();
 
         if (itsPrettyPrint)
           itsPrettyWriter.~JSONWriter();


### PR DESCRIPTION
Fixed a bug in JSONPlainWriter destruction when the top-level node is an array